### PR TITLE
fix: Update logo path to import from src directory

### DIFF
--- a/src/pages/FabricsLanding.tsx
+++ b/src/pages/FabricsLanding.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { MapPin, Mail, Clock, MessageSquare, Star, Shield, Users, Eye, UserCheck, Headphones, TrendingUp, CheckCircle, Quote } from 'lucide-react';
+import logoUrl from '../create-logo-of-logistic-company-named---dragonwise.png';
 
 const FabricsLanding = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -105,7 +106,7 @@ const FabricsLanding = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-center">
             <img 
-              src="/create-logo-of-logistic-company-named---dragonwise.png" 
+              src={logoUrl}
               alt="DragonWise Logo" 
               className="h-20 w-auto"
             />


### PR DESCRIPTION
Updated the FabricsLanding page to import the DragonWise logo from `src/create-logo-of-logistic-company-named---dragonwise.png` instead of referencing it from the public directory.

This allows Vite to process the image and include it in the build.