### PR TITLE
fix: Update logo path to reference image in public directory

### DIFF
--- a/src/pages/FabricsLanding.tsx
+++ b/src/pages/FabricsLanding.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { MapPin, Mail, Clock, MessageSquare, Star, Shield, Users, Eye, UserCheck, Headphones, TrendingUp, CheckCircle, Quote } from 'lucide-react';
-import logoUrl from '../create-logo-of-logistic-company-named---dragonwise.png';
 
 const FabricsLanding = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -106,7 +105,7 @@ const FabricsLanding = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-center">
             <img 
-              src={logoUrl}
+              src="/logo-dragonwise.png"
               alt="DragonWise Logo" 
               className="h-20 w-auto"
             />


### PR DESCRIPTION
Reverted previous change that imported logo from `src`. Updated the `<img>` tag in `FabricsLanding.tsx` to use the direct path `/logo-dragonwise.png`, assuming the image exists in the `public` directory as per user confirmation.