### PR TITLE
fix: Update logo path in main Header component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -60,7 +60,7 @@ const Header = () => {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <img 
-              src="/create-logo-of-logistic-company-named---dragonwise.png" 
+              src="/logo-dragonwise.png"
               alt="DragonWise Logo" 
               className="h-20 w-auto"
             />


### PR DESCRIPTION
Updated the `src` attribute for the logo in `src/components/Header.tsx` to use `/logo-dragonwise.png`.

This ensures the correct logo is displayed on the main landing page, aligning with the working logo path on the Fabrics landing page.